### PR TITLE
hrc/sh.hrc

### DIFF
--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -150,7 +150,13 @@
 
 <scheme name="string">
 <!-- TODO: add support of single-quoted and double-quoted heredoc delimiter -->
- <block start="/(&lt;&lt;-?\s*\\?)([\w-]+)/" end="/^(\y2)/"
+ <block start="/(&lt;&lt;-\s*\\?)([\w-]+)/" end="/^\s*(\y2)/"
+  scheme="slash" region="perl:HereDoc"
+  region00="def:PairStart" region10="def:PairEnd"
+  region01="perl:HereDocLt" region02="perl:HereDocName"
+  region11="perl:HereDocName"
+ />
+ <block start="/(&lt;&lt;\s*\\?)([\w-]+)/" end="/^(\y2)/"
   scheme="slash" region="perl:HereDoc"
   region00="def:PairStart" region10="def:PairEnd"
   region01="perl:HereDocLt" region02="perl:HereDocName"


### PR DESCRIPTION
I'd like to suggest 3 little improvements for colorizing shell scripts in the editor:
1. variable expansions: ${#...} ${!...}
   The first one is colorized as a comment. I think the better way to consider both ${! and ${# as the start of block the same way as ${.
2. processing of the modern bash brackets such as (( )) and [[ ]]
   It could be more convenient if (( )) and [[ ]] were considered as paired brackets (used in modern BASH) instead of two separate nested brackets ( ) and [ ]. 
3. the better support of heredoc
   The marker is not restricted by EOxxx as in the previous version; also added support of <<-marker. 
