### PR TITLE
hrc/sh.hrc

### DIFF
--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -55,15 +55,12 @@
  />
 </scheme>
 <scheme name="shell">
- <inherit scheme="def:unixCommentDirective"/>
-
- <block start="/\#/" end="/$/" region="def:Comment" scheme="def:Comment"/>
-
  <inherit scheme="string.eval"/>
  <inherit scheme="shell.in"/>
 </scheme>
 
 <scheme name="shell.in">
+ <block start="/\#/" end="/$/" region="def:Comment" scheme="def:Comment"/>
 
  <block start="/(\{)/" end="/(\})/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -65,7 +65,7 @@
 
 <scheme name="shell.in">
 
- <block start="/(\{)/" end="/(\})/" scheme="shell.in"
+ <block start="/(\{)/" end="/(\})/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -157,7 +157,7 @@
   region01="perl:HereDocLt" region02="perl:HereDocName"
   region11="perl:HereDocName"
  />
- <block start="/(&lt;&lt;\s*\\?)(EO\w+)/" end="/^(\y2)/"
+ <block start="/(&lt;&lt;\s*\\?)([\w-]+)/" end="/^(\y2)/"
   scheme="slash" region="perl:HereDoc"
   region00="def:PairStart" region10="def:PairEnd"
   region01="perl:HereDocLt" region02="perl:HereDocName"

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -74,11 +74,11 @@
   region01="var" region11="var"
  />
  <regexp match="/^(%var;)(\(\))/" region1="def:Outlined" region2="symb"/>
- <block start="/(\(\()/" end="/(\)\))/" scheme="shell.in"
+ <block start="/(\$?\(\()/" end="/(\)\))/" scheme="shell.in"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />
- <block start="/(\()/" end="/(\))/" scheme="shell.in"
+ <block start="/(\$?\()/" end="/(\))/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />


### PR DESCRIPTION
1. more words as a label of heredocs: 
The actual EO\w+ is extremely restricted regexp to cover any kind of heredoc labels. More frequently they use any set of symbols corresponding this [\w-]+ regexp. There is no reason to restrict heredocs by using EO\w+ only. 

2. $(Process Substitution), $((Arithmetic Expansion)): 
Support of nowaday syntax for arithmetic expansions. Better highlighting of process substitution. 

Added comment: the 3rd and 4th commits are not offered for merging to the main repository due to they are under construction yet. 