### PR TITLE
hrc/sh.hrc: process redirection and few descriptive comments

### DIFF
--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -55,6 +55,8 @@
  />
 </scheme>
 <scheme name="shell">
+<inherit scheme="def:unixCommentDirective"/>
+<block start="/\#/" end="/$/" region="def:Comment" scheme="def:Comment"/>
  <inherit scheme="string.eval"/>
  <inherit scheme="shell.in"/>
 </scheme>

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -80,7 +80,9 @@
   region01="symb.struct" region11="symb.struct"
  />
 <!-- $( ... ) -->
- <block start="/(\$?\()/" end="/(\))/" scheme="shell"
+<!-- <( ... ) -->
+<!-- >( ... ) -->
+ <block start="/([&lt;&gt;$]?\()/" end="/(\))/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -62,27 +62,34 @@
 <scheme name="shell.in">
  <block start="/\#/" end="/$/" region="def:Comment" scheme="def:Comment"/>
 
+<!-- { ... } -->
  <block start="/(\{)/" end="/(\})/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />
+<!-- ${ ... } -->
  <block start="/(\$\{[!#]?)/" end="/(\})/" scheme="shell.in"
   region00="def:PairStart" region10="def:PairEnd"
   region01="var" region11="var"
  />
+<!-- fn() -->
  <regexp match="/^(%var;)(\(\))/" region1="def:Outlined" region2="symb"/>
+<!-- $(( ... )) -->
  <block start="/(\$?\(\()/" end="/(\)\))/" scheme="shell.in"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />
+<!-- $( ... ) -->
  <block start="/(\$?\()/" end="/(\))/" scheme="shell"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb.struct" region11="symb.struct"
  />
+<!-- [[ ... ]] -->
  <block start="/(?:^|\s)(\[\[) /" end="/ (\]\])/" scheme="shell.in"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb" region11="symb"
  />
+<!-- [ ... ] -->
  <block start="/(?:^|\s)(\[) /" end="/ (\])/" scheme="shell.in"
   region00="def:PairStart" region10="def:PairEnd"
   region01="symb" region11="symb"


### PR DESCRIPTION
- descriptive comments added
- process substitution <() and >() highlighted similar to subprocess execution $()
- attempt to return shebang coloring