### PR TITLE
Add Haskell color file

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -861,6 +861,10 @@
     <location link="rare/sml.hrc"/>
     <filename>/\.(sml|sig)$/i</filename>
   </prototype>
+  <prototype name="haskell" group="rare" description="Haskell">
+    <location link="haskell.hrc"/>
+    <filename>/\.(hs|cf)$/i</filename>
+  </prototype>
   <prototype name="ocaml" group="rare" description="OCaml">
     <location link="rare/ocaml.hrc"/>
     <filename>/\.ml[ilpy]?$/i</filename>

--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -863,7 +863,7 @@
   </prototype>
   <prototype name="haskell" group="rare" description="Haskell">
     <location link="haskell.hrc"/>
-    <filename>/\.(hs|cf)$/i</filename>
+    <filename>/\.hs$/i</filename>
   </prototype>
   <prototype name="ocaml" group="rare" description="OCaml">
     <location link="rare/ocaml.hrc"/>

--- a/hrc/hrc/rare/haskell.hrc
+++ b/hrc/hrc/rare/haskell.hrc
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="windows-1251"?>
+<!DOCTYPE hrc PUBLIC "-//Cail Lomecb//DTD Colorer HRC take5//EN"
+  "http://colorer.sf.net/2003/hrc.dtd">
+<hrc version="take5" xmlns="http://colorer.sf.net/2003/hrc"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hrc.xsd">
+   <type name="haskell">
+      <annotation>
+         <documentation><![CDATA[
+           Haskell Syntax
+           <filename>/\.(hs)$/i</filename>
+         ]]></documentation>
+         <contributors>
+           Jens Lidestrom
+         </contributors>
+      </annotation>
+
+      <!-- 
+        Features:
+
+          * Line comments
+          * Block comments
+          * Pragmas
+          * Keywords
+          * Keywords for only import statements
+          * Strings (Copied from OCaml)
+          * Brackets
+          * Highlight types and constructors based on initial upper case letter
+          * Outline for function, type, class etc. declaration (based more on code conventions than on syntax but still)
+      -->
+      
+      <!-- TODO:
+        * Operator constructors (startning with :)
+        * Operators starting with dash-dash
+        * Multi line string
+        * Handle function clauses inside pairs?
+      -->
+      
+      <!-- TODO: Handler numbers and syms in identifiers? -->      
+      <entity name="ident" value="[_\w]" />
+
+      <region name="String" parent="def:String"/>
+      <region name="Comment" parent="def:Comment"/>
+      <region name="LineComment" parent="def:LineComment"/>
+      <region name="Symbol" parent="def:Symbol"/>
+      <region name="Keyword" parent="def:Keyword"/>
+      <region name="Number" parent="def:Number"/>
+      <region name="PairStart" parent="def:PairStart"/>
+      <region name="PairEnd" parent="def:PairEnd"/>
+      
+      <region name="StringEscape" parent="c:StringEscape"/>
+
+      <!-- From Ocaml -->
+      <scheme name="StringContent">
+          <regexp match="/\\\\$/" region="def:Error"/>
+          <regexp match="/\\[^xX\d]/" region="StringEscape"/>
+          <regexp match="/\\$/" region="StringEscape"/>
+          <regexp match="/\\x[\da-fA-F]{1,8}/i" region="StringEscape"/>
+          <regexp match="/\\[0-9]{1,3}/" region="StringEscape"/>
+          <regexp match="/\%[\-\+\#0]*?[\d\*]*(\.[\d\*]+)?[Ll]?[SsCcsuidopxXnEefgG]/" region="StringEscape"/>
+          <regexp match="/[^\\\&#34;]$/" region="def:Error"/>
+      </scheme>
+      
+      <scheme name="String">
+          <block start="/&#34;/" end="/&#34;/" scheme="StringContent" region="String"
+                region00="PairStart" region10="PairEnd"/>
+      </scheme>
+      
+      <!-- Scheme for imports and module decl -->
+      <scheme name="HaskellHeader" >
+        <inherit scheme="HaskellCommon" >
+            <virtual scheme="haskell" subst-scheme="HaskellHeader" />
+        </inherit>
+            
+        <keywords region="Keyword">
+          <word name="module"/>
+          <word name="import"/>
+          <word name="qualified"/>
+          <word name="as"/>
+          <word name="hiding"/>
+        </keywords>
+      </scheme>
+      
+      <!-- Paired things -->
+      <scheme name="HaskellPaired">
+         <block start="/(\()/" end="/(\))/" scheme="haskell" 
+            region00="Symbol" region01="PairStart" 
+            region10="Symbol" region11="PairEnd"/>
+         <block start="/(\[)/" end="/(\])/" scheme="haskell"
+            region00="Symbol" region01="PairStart" 
+            region10="Symbol" region11="PairEnd"/>
+         <block start="/(\{)/" end="/(\})/" scheme="haskell" 
+            region00="Symbol" region01="PairStart" 
+            region10="Symbol" region11="PairEnd"/>
+      </scheme>
+
+      <scheme name="HaskellBlockComment">
+          <!-- Removed because it inherits todo which is a little weird. 
+            <inherit scheme="def:Comment"/> 
+          -->
+          <!-- Pragmas -->
+          <block scheme="HaskellBlockComment" region="Comment" 
+              region00="PairStart"
+              region10="PairEnd" 
+              start="/\{-#/" end="/#-\}/"/>
+          
+          <!-- Normal comments -->
+          <block scheme="HaskellBlockComment" region="Comment" 
+              region01="PairStart"
+              region11="PairEnd" 
+              start="/(\{-)/" end="/(-\})/"/>
+
+      </scheme>
+      <scheme name="HaskellLineComment">
+          <!-- Removed because it inherits todo which is a little weird. 
+            <inherit scheme="def:Comment"/> -->
+          <block start="/--/" end="/$/" scheme="HaskellLineComment" region="LineComment"/>
+      </scheme>
+      
+      <!-- Scheme for all comments, line and block -->
+      <scheme name="HaskellComment">
+          <inherit scheme="HaskellBlockComment" />
+          <inherit scheme="HaskellLineComment" />
+      </scheme>
+      
+      <!-- Things used both in the header and normal code -->
+      <scheme name="HaskellCommon">
+        <inherit scheme="HaskellComment" />
+        <inherit scheme="HaskellPaired"/>
+
+         <!-- CPP preprocessor directives, just capture to end of line -->
+         <regexp match="/#(if|ifdef|ifndef|else|endif|include|define|undef|line|pragma) .* /x" 
+                 region="def:Directive" />
+
+         <!-- Everything starting with cap letter, types and constructors -->
+        <regexp match="/ \b \u%ident;* /x" region="def:ClassKeyword"/>
+        
+        <inherit scheme="HaskellSymbols" />
+      </scheme>
+      
+      <scheme name="haskell">
+         
+         <!-- Outline for operators -->
+         <regexp match="/^ \M (?{def:Outlined} \( .* ) $ /x"/>
+
+         <!-- Comments -->
+         <inherit scheme="HaskellCommon" />
+         
+         <!--
+            Attempt to capture one function clause which didn't really work
+         <block scheme="haskell" start="/^ \M %ident;+ /x" 
+            end="/s\M ^((?!\y1)%ident) /xs" 
+            region00="PairStart" region10="PairEnd"
+          />
+         -->
+         
+         <!-- Things that are both outlined and keywords -->
+         <regexp match="/^ \M (?{def:Outlined} (data|newtype|type|class|instance) \s .* ) $ /x" />
+ 
+         <!-- Character constants -->
+         <regexp match="/('.')|('\\n')|('\\t')|('\\0')|('&#34;')|('\\&#34;')|('\\\\')/" region="def:Character" />
+         <!-- Integer constants  0 ~0 4 ~04 999999 0xffff -->
+         <regexp match="/\~?\b(\d+|0x[\da-fA-F]+)\b/" region="Number" />
+         <!-- Real constants  0.7 ~0.7 3.32E5 3E~7 ~3E~7 3e~7 ~3e~7 -->
+         <regexp match="/\~?\b([0-9]+[\.]?[0-9]*(e[\~]?[\d]+)?)\b/i" region="Number" />
+
+         <!-- String constants -->
+         <inherit scheme="String"/>
+         
+         <!-- Imports -->
+         <block start="/\M import/x" end="/$/" scheme="HaskellHeader" /> 
+         <!-- Module -->
+         <block start="/\M module/x" end="/\M where/" scheme="HaskellHeader" /> 
+
+         <inherit scheme="HaskellKeywords" />
+
+         <!-- Outline for functions, capture anything with a ident at first column and a type 
+              declaration. Things that can be both keywords and outline should be outlined must
+              go before keywords. -->
+         <regexp match="/^ \M (?{def:Outlined} %ident; .* :: .*) $ /ix"/>
+      </scheme>
+
+      <scheme name="HaskellKeywords">
+         <keywords region="Keyword">
+            <word name="case"/>
+            <word name="do"/>
+            <word name="else"/>
+            <word name="if"/>
+            <word name="in"/>
+            <word name="infix"/>
+            <word name="infixr"/>
+            <word name="infixl"/>
+            <word name="let"/>
+            <word name="of"/>
+            <word name="then"/>
+            <word name="type"/>
+            <word name="class"/>
+            <word name="data"/>
+            <word name="foreign"/>
+            <word name="instance"/>
+            <word name="newtype"/>
+            <word name="deriving"/>
+            <word name="where"/>
+         </keywords>
+      </scheme>
+      
+      <scheme name="HaskellSymbols">
+         <!-- Symbols -->
+         <keywords region="Symbol">
+            <symb name=","/>
+            <symb name=":"/>
+            <symb name=";"/>
+            <symb name="|"/>
+            <symb name="="/>
+            <symb name="#"/>
+            <symb name="*"/>
+            <symb name="+"/>
+            <symb name="^"/>
+            <symb name="~"/>
+            <symb name="-"/>
+            <symb name="/"/>
+            <symb name="("/>
+            <symb name=")"/>
+            <symb name="["/>
+            <symb name="]"/>
+            <symb name="{"/>
+            <symb name="}"/>
+            <symb name="&lt;"/>
+            <symb name="&gt;"/>
+            <symb name="\"/>
+            <symb name="&amp;"/>
+            <symb name="."/>
+            <symb name="$"/>
+            <symb name="@"/>
+            <symb name="`"/>
+            <symb name="!"/>
+         </keywords>
+      </scheme>
+      
+   </type>
+</hrc>
+<!-- ***** BEGIN LICENSE BLOCK *****
+   - Version: MPL 1.1/GPL 2.0/LGPL 2.1
+   -
+   - The contents of this file are subject to the Mozilla Public License Version
+   - 1.1 (the "License"); you may not use this file except in compliance with
+   - the License. You may obtain a copy of the License at
+   - http://www.mozilla.org/MPL/
+   -
+   - Software distributed under the License is distributed on an "AS IS" basis,
+   - WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+   - for the specific language governing rights and limitations under the
+   - License.
+   -
+   - The Original Code is the Colorer Library.
+   -
+   - The Initial Developer of the Original Code is
+   - Cail Lomecb <cail@nm.ru>.
+   - Portions created by the Initial Developer are Copyright (C) 1999-2005
+   - the Initial Developer. All Rights Reserved.
+   -
+   - Contributor(s):
+   -
+   - Alternatively, the contents of this file may be used under the terms of
+   - either the GNU General Public License Version 2 or later (the "GPL"), or
+   - the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+   - in which case the provisions of the GPL or the LGPL are applicable instead
+   - of those above. If you wish to allow use of your version of this file only
+   - under the terms of either the GPL or the LGPL, and not to allow others to
+   - use your version of this file under the terms of the MPL, indicate your
+   - decision by deleting the provisions above and replace them with the notice
+   - and other provisions required by the LGPL or the GPL. If you do not delete
+   - the provisions above, a recipient may use your version of this file under
+   - the terms of any one of the MPL, the GPL or the LGPL.
+   -
+   - ***** END LICENSE BLOCK ***** -->


### PR DESCRIPTION
I have created this color file for the Haskell language.

It is very useful and covers at least the common parts of the language.

Features:
* Line comments
* Block comments
* Pragmas
* Keywords
* Keywords for import statements only (such as "as" and "qualified")
* Strings (Copied from OCaml)
* Brackets
* Highlight types and constructors based on initial upper case letter
* Outline for function, type, class etc. declaration (based somewhat on code conventions instead of on syntax, but still)

Haskell support for Eclipse is otherwise pretty lacking. The EclipseFP plugin is still a bit shaky. Colorer might fill a gap here.

I used the Ocaml file as a starting point. 
