### PR TITLE
Improved fsharp.hrc

### DIFF
--- a/hrc/hrc/base/fsharp.hrc
+++ b/hrc/hrc/base/fsharp.hrc
@@ -7,21 +7,39 @@ xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hr
 <type name="fsharp">
 <annotation><documentation><![CDATA[
 
-fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
+fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-09-06
 
 ]]></documentation></annotation>
 
-<import type="def"/>
+<region parent="def:Comment" name="Comment"/>
+<region parent="def:CommentDoc" name="CommentDoc"/>
+<region parent="def:Constant" name="Constant"/>
+<region parent="def:Directive" name="Directive"/>
+<region parent="def:Identifier" name="Function"/>
+<region parent="def:Identifier" name="Identifier"/>
+<region parent="def:Identifier" name="Member"/>
+<region parent="def:Identifier" name="Module"/>
+<region parent="def:Identifier" name="Type"/>
+<region parent="def:Identifier" name="Variable"/>
+<region parent="def:Keyword" name="Keyword"/>
+<region parent="def:NumberDec" name="NumberDec"/>
+<region parent="def:NumberFloat" name="NumberFloat"/>
+<region parent="def:NumberHex" name="NumberHex"/>
+<region parent="def:Operator" name="Operator"/>
+<region parent="def:PairEnd" name="PairEnd"/>
+<region parent="def:PairStart" name="PairStart"/>
+<region parent="def:String" name="String"/>
+<region parent="def:StringContent" name="StringContent"/>
 
 <!-- Identifier -->
-<entity name="ident" value="[_a-zA-Z][\w&apos;]*"/>
+<entity name="ident" value="(?:[_a-zA-Z][.\w&apos;]*|``.+?``)"/>
 
 <!-- Escaped -->
 <scheme name="FSSimpleString">
-<regexp match="/\\[bnrt\\&quot;&apos;]|\\$|\\u[\da-fA-F]{4}|\\U[\da-fA-F]{8}/" region="def:StringContent"/>
+<regexp match="/\\[bnrt\\&quot;&apos;]|\\$|\\u[\da-fA-F]{4}|\\U[\da-fA-F]{8}/" region="StringContent"/>
 </scheme>
 <scheme name="FSVerbatimString">
-<regexp match="/&quot;&quot;/" region="def:StringContent"/>
+<regexp match="/&quot;&quot;/" region="StringContent"/>
 </scheme>
 <scheme name="FSVerbatimString2">
 </scheme>
@@ -31,74 +49,99 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <entity name="numsuf" value="[fFmM]?"/>
 <entity name="intsuf" value="(y|uy|s|us|L|UL)?"/>
 <scheme name="FSNumber">
-<regexp match="/\B\.?~1\.\d+%numexp;?%numsuf;\b/i" region="def:NumberFloat"/>
-<regexp match="/\b\d+\.\.?!\d*(?:%numexp;?%numsuf;\b|\B)/i" region="def:NumberFloat"/>
-<regexp match="/\b\d+%numexp;%numsuf;\b/i" region="def:NumberFloat"/>
-<regexp match="/\b0[xX][\da-fA-F]+%intsuf;(?:Fun)?\b/i" region="def:NumberHex"/>
-<regexp match="/\b\d+%intsuf;\b/i" region="def:NumberDec"/>
+<regexp match="/\B\.?~1\.\d+%numexp;?%numsuf;\b/i" region="NumberFloat"/>
+<regexp match="/\b\d+\.\.?!\d*(?:%numexp;?%numsuf;\b|\B)/i" region="NumberFloat"/>
+<regexp match="/\b\d+%numexp;%numsuf;\b/i" region="NumberFloat"/>
+<regexp match="/\b0[xX][\da-fA-F]+%intsuf;(?:Fun)?\b/i" region="NumberHex"/>
+<regexp match="/\b\d+%intsuf;\b/i" region="NumberDec"/>
 </scheme>
 
 <!-- Content (**) -->
 <scheme name="FSCommentContent">
-<block start="/&quot;/" end="/&quot;B?/" scheme="def:Comment" region="def:Comment" region00="def:PairStart" region10="def:PairEnd"/>
+<block start="/&quot;/" end="/&quot;B?/" scheme="def:Comment" region="Comment" region00="PairStart" region10="PairEnd"/>
 </scheme>
 
 <!-- Main scheme -->
 <scheme name="fsharp">
 
 <!-- Special (*) -->
-<regexp match="/\(\*\)/" region="def:Operator"/>
-
-<!-- Unusual identifier -->
-<regexp match="/(``)(.+?)(``)/" region="def:Identifier" region1="def:PairStart" region3="def:PairEnd"/>
+<regexp match="/\(\*\)/" region="Operator"/>
 
 <!-- Block comment -->
-<block start="/\(\*/" end="/\*\)/" scheme="FSCommentContent" region00="def:PairStart" region10="def:PairEnd" region="def:Comment"/>
+<block start="/\(\*/" end="/\*\)/" scheme="FSCommentContent" region00="PairStart" region10="PairEnd" region="Comment"/>
 
 <!-- Line comment -->
-<regexp match="/(?:^|\s)(////(?:\s+.*|$))/" region="def:Comment" region1="def:Outlined"/>
-<regexp match="/(?:^|\s)(///)(\s+.*|$)/" region1="def:CommentDoc" region2="def:Comment"/>
-<regexp match="/\/\/.*/" region="def:Comment"/>
+<regexp match="/(?:^|\s)(////(?:\s+.*|$))/" region="Comment" region1="def:Outlined"/>
+<regexp match="/(?:^|\s)(///)(\s+.*|$)/" region1="CommentDoc" region2="Comment"/>
+<regexp match="/\/\/.*/" region="Comment"/>
 
 <!-- String -->
-<block start="/&quot;&quot;&quot;/" end="/&quot;&quot;&quot;B?/" scheme="FSVerbatimString2" region="def:String" region00="def:PairStart" region10="def:PairEnd"/>
-<block start="/@&quot;/" end="/&quot;B?/" scheme="FSVerbatimString" region="def:String" region00="def:PairStart" region10="def:PairEnd"/>
-<block start="/&quot;/" end="/&quot;B?/" scheme="FSSimpleString" region="def:String" region00="def:PairStart" region10="def:PairEnd"/>
+<block start="/&quot;&quot;&quot;/" end="/&quot;&quot;&quot;B?/" scheme="FSVerbatimString2" region="String" region00="PairStart" region10="PairEnd"/>
+<block start="/@&quot;/" end="/&quot;B?/" scheme="FSVerbatimString" region="String" region00="PairStart" region10="PairEnd"/>
+<block start="/&quot;/" end="/&quot;B?/" scheme="FSSimpleString" region="String" region00="PairStart" region10="PairEnd"/>
 
 <!-- Character -->
-<regexp match="/&apos;(\\&apos;|\\[bnrt\\&apos;&quot;]|\\u[\da-fA-F]{4}|\\U[\da-fA-F]{8}|.)&apos;B?/" region="def:String"/>
+<regexp match="/&apos;(\\&apos;|\\[bnrt\\&apos;&quot;]|\\u[\da-fA-F]{4}|\\U[\da-fA-F]{8}|.)&apos;B?/" region="String"/>
 
 <!-- Array -->
-<block start="/\[\|/" end="/\|\]/" scheme="fsharp" region00="def:PairStart" region10="def:PairEnd"/>
+<block start="/\[\|/" end="/\|\]/" scheme="fsharp" region00="PairStart" region10="PairEnd"/>
 
 <!-- Attribute -->
-<block start="/\[&lt;/" end="/&gt;\]/" scheme="fsharp" region00="def:PairStart" region10="def:PairEnd"/>
+<block start="/\[&lt;/" end="/&gt;\]/" scheme="fsharp" region00="PairStart" region10="PairEnd"/>
 
-<!-- Code Quotations -->
-<block start="/&lt;@@/" end="/@@&gt;/" scheme="fsharp" region00="def:PairStart" region10="def:PairEnd"/>
-<block start="/&lt;@/" end="/@&gt;/" scheme="fsharp" region00="def:PairStart" region10="def:PairEnd"/>
+<!-- Code Quotation -->
+<block start="/&lt;@@/" end="/@@&gt;/" scheme="fsharp" region00="PairStart" region10="PairEnd"/>
+<block start="/&lt;@/" end="/@&gt;/" scheme="fsharp" region00="PairStart" region10="PairEnd"/>
 
-<!-- Brackets -->
+<!-- Bracket -->
 <inherit scheme="def:PairedBrackets">
 <virtual scheme="def:PairedBrackets" subst-scheme="fsharp"/>
 </inherit>
 
-<!-- Directives -->
-<regexp match="/^\s*#(if|else|endif|light|nowarn|r|reference|I|Include|load)\b/" region="def:Directive"/>
+<!-- Directive -->
+<regexp match="/^\s*#(if|else|endif|light|nowarn|r|reference|I|Include|load)\b/" region="Directive"/>
 
-<!-- Outlined -->
-<regexp match="/^(let(?:\s+(?:rec|mutable|inline))?(?:\s+(?:public|private|internal))?)\s+(%ident;)/" region1="def:Keyword" region2="def:Identifier" region="def:Outlined"/>
-<regexp match="/^(type(?:\s+(?:public|private|internal))?)\s+(%ident;)/" region1="def:Keyword" region2="def:Identifier" region="def:Outlined"/>
-<regexp match="/^\s+(static|member|override)\s+/" region1="def:Keyword" region="def:Outlined"/>
+<!-- Variable -->
+<regexp
+match="/^\s*(static)?\b\s*(let)\b\s*(mutable)?\b\s*(public|private|internal)?\s+(%ident;)\s*[=:,]?=/"
+region1="Keyword" region2="Keyword" region3="Keyword" region4="Keyword" region5="Variable"
+/>
 
-<keywords region="def:Constant">
+<!-- Function -->
+<regexp region="def:Outlined"
+match="/^\s*(static)?\b\s*(let)\b\s*(rec|inline)?\b\s*(public|private|internal)?\s+(%ident;)/"
+region1="Keyword" region2="Keyword" region3="Keyword" region4="Keyword" region5="Function"
+/>
+
+<!-- Module -->
+<regexp region="def:Outlined"
+match="/^\s*(module|namespace)\b\s*(public|private|internal)?\s+(%ident;)/"
+region1="Keyword" region2="Keyword" region3="Module"
+/>
+
+<!-- Type -->
+<regexp region="def:Outlined"
+match="/^\s*(type|interface|exception)\b\s*(public|private|internal)?\s+(%ident;)/"
+region1="Keyword" region2="Keyword" region3="Type"
+/>
+
+<!-- Member -->
+<regexp region="def:Outlined"
+match="/^\s+(static)?\b\s*(member|override|abstract)\b\s*(val|inline)?\b\s*(public|private|internal)?\s+(%ident;|\(?=)/"
+region1="Keyword" region2="Keyword" region3="Keyword" region4="Keyword" region5="Member"
+/>
+
+<keywords region="Constant">
 <word name="__SOURCE_DIRECTORY__"/>
 <word name="__SOURCE_FILE__"/>
 <word name="__LINE__"/>
+<word name="false"/>
+<word name="null"/>
+<word name="true"/>
 </keywords>
 
-<!-- Keywords -->
-<keywords region="def:Keyword">
+<!-- Keyword -->
+<keywords region="Keyword">
 <word name="abstract"/>
 <word name="and"/>
 <word name="as"/>
@@ -117,7 +160,6 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <word name="end"/>
 <word name="exception"/>
 <word name="extern"/>
-<word name="false"/>
 <word name="finally"/>
 <word name="for"/>
 <word name="fun"/>
@@ -138,7 +180,6 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <word name="namespace"/>
 <word name="new"/>
 <word name="not"/>
-<word name="null"/>
 <word name="of"/>
 <word name="open"/>
 <word name="or"/>
@@ -151,7 +192,6 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <word name="struct"/>
 <word name="then"/>
 <word name="to"/>
-<word name="true"/>
 <word name="try"/>
 <word name="type"/>
 <word name="upcast"/>
@@ -200,8 +240,8 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <word name="volatile"/>
 </keywords>
 
-<!-- Operators -->
-<keywords region="def:Operator">
+<!-- Operator -->
+<keywords region="Operator">
 <symb name="!"/>
 <symb name="%"/>
 <symb name="&amp;"/>
@@ -248,15 +288,10 @@ fsharp.hrc by Roman Kuzmin, aka NightRoman, 2016-08-14
 <symb name="~+"/>
 </keywords>
 
-<!-- Identifiers -->
-<regexp match="/%ident;/" region="def:Identifier"/>
+<!-- Identifier -->
+<regexp match="/%ident;/" region="Identifier"/>
 
-<!-- Pipeline -->
-<keywords region="def:KeywordStrong">
-<symb name="|&gt;"/>
-</keywords>
-
-<!-- Numbers (after redirections) -->
+<!-- Number -->
 <inherit scheme="FSNumber"/>
 
 </scheme>


### PR DESCRIPTION
- Use derived regions instead of default.
- Treat false, true, null as constants.
- Review F# identifier patterns.
- Improve outlined items.