### PR TITLE
colorize bash/ksh/zsh profile setting files

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -542,6 +542,8 @@
     <location link="scripts/sh.hrc"/>
     <filename>/\.(sh|spec)$/i</filename>
     <filename>/^PKGBUILD$/i</filename>
+    <filename>/\.(bash_|z)?profile/</filename>
+    <filename>/\.(ba|k|z)?shrc/</filename>
     <firstline weight='2'>/^\#(!\s*.+sh\b)/</firstline>
   </prototype>
   <prototype name="avisynth" group="scripts" description="AviSynth">


### PR DESCRIPTION
colorize profile setting files in the same way as to regular shell scripts.
Supportable shells:
	bash/ksh/zsh
Supportable files:
	.bashrc
	.kshrc
	.zshrc
	.bash_profile
	.profile
	.zprofile