### PR TITLE
Hrc jscript

### DIFF
--- a/hrc/hrc/inet/jscript.hrc
+++ b/hrc/hrc/inet/jscript.hrc
@@ -488,7 +488,7 @@
             <virtual scheme="PairedBrackets" subst-scheme="jScript"/>
          </inherit>
 <!-- Labels -->
-         <regexp match="/^\s*\w+(:)$/" region0="Label"/>
+         <regexp match="/^\s*(\w+\:)$/" region1="Label"/>
 <!-- Numbers -->
          <inherit scheme="def:Number"/>
 <!-- Strings -->

--- a/hrc/hrc/inet/jscript.hrc
+++ b/hrc/hrc/inet/jscript.hrc
@@ -487,6 +487,8 @@
          <inherit scheme="PairedBrackets">
             <virtual scheme="PairedBrackets" subst-scheme="jScript"/>
          </inherit>
+<!-- Labels -->
+         <regexp match="/^\s*\w+(:)$/" region0="Label"/>
 <!-- Numbers -->
          <inherit scheme="def:Number"/>
 <!-- Strings -->


### PR DESCRIPTION
A small improvement to jscript scheme that allows to colorize javascript labels independently of the number of whitespaces at the beginning of the labels. 