### PR TITLE
Fix fragile buildscript

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,10 @@
 
 # rem path to java libs
-export CLR_JL=./javalib
+CLR_JL="$( dirname "$( readlink -f "$0" )" )/javalib"
+export CLR_JL
 
-export CLASSPATH=$CLR_JL/commons-net-ftp-2.0.jar:$CLR_JL/commons-net-2.0.jar:$CLR_JL/resolver.jar:$CLR_JL/saxon9.jar:$CLASSPATH
+CLASSPATH="$CLR_JL/commons-net-ftp-2.0.jar:$CLR_JL/commons-net-2.0.jar:$CLR_JL/resolver.jar:$CLR_JL/saxon9.jar${CLASSPATH+:}$CLASSPATH"
+export CLASSPATH
 
-echo $CLASSPATH
-ant $*
+echo "$CLASSPATH"
+ant "$@"


### PR DESCRIPTION
Use absolute paths.
Added quoting to shield against unsafe characters in CLASSPATH and parameters.