### PR TITLE
Treat .*proj files as XML.

### DIFF
--- a/hrc/hrc/base/fsharp.hrc
+++ b/hrc/hrc/base/fsharp.hrc
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hr
 <type name="fsharp">
 <annotation><documentation><![CDATA[
 
-fsharp.hrc by Roman Kuzmin, aka nightroman, 2016-12-15
+fsharp.hrc by Roman Kuzmin, aka nightroman, 2017-09-14
 
 ]]></documentation></annotation>
 
@@ -120,8 +120,7 @@ region1="Keyword" region2="Keyword" region3="Keyword" region4="Keyword" region5=
 
 <!-- Module -->
 <regexp region="def:Outlined"
-match="/^\s*(module|namespace)\b\s*(public|private|internal)?\s+(%ident;)/"
-region1="Keyword" region2="Keyword" region3="Module"
+match="/^\s*(?{Keyword}module|namespace)\b(?:\s+(?{Keyword}public|private|internal))?(?:\s+(?{Keyword}rec))?\s+(?{Module}%ident;)/"
 />
 
 <!-- Type -->

--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -373,7 +373,7 @@
   <!--  xml types  -->
   <prototype name="xml" group="xml" description="xml">
     <location link="xml/xml.hrc"/>
-    <filename>/\.(xml|gi2|gpr|ui)$/i</filename>
+    <filename>/\.(xml|\w*proj|gi2|gpr|ui)$/i</filename>
     <filename>/\.(wxs|fb2)$/i</filename>
     <firstline>/^&lt;\?xml | &lt;\!DOCTYPE | xmlns /x</firstline>
     <firstline>/^\s*&lt;\w+&gt;\s*/</firstline><!-- (\s+\w+\s*=\*([&quot;&apos;]).+?\2)*\s* -->


### PR DESCRIPTION
New MSBuild project files do not have traditional XML declaration.
It looks like the pattern .*proj does not conflict with other types.