### PR TITLE
Treat .*proj files as XML.

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -373,7 +373,7 @@
   <!--  xml types  -->
   <prototype name="xml" group="xml" description="xml">
     <location link="xml/xml.hrc"/>
-    <filename>/\.(xml|gi2|gpr|ui)$/i</filename>
+    <filename>/\.(xml|\w*proj|gi2|gpr|ui)$/i</filename>
     <filename>/\.(wxs|fb2)$/i</filename>
     <firstline>/^&lt;\?xml | &lt;\!DOCTYPE | xmlns /x</firstline>
     <firstline>/^\s*&lt;\w+&gt;\s*/</firstline><!-- (\s+\w+\s*=\*([&quot;&apos;]).+?\2)*\s* -->


### PR DESCRIPTION
New MSBuild project files do not have traditional XML declaration. As a result,
they are not recognised as XML files because .*proj is not in the XML pattern.
It looks like the pattern .*proj does not conflict with other types.