### PR TITLE
markdown.hrc - support fenced code blocks with language names

### DIFF
--- a/hrc/hrc/misc/markdown.hrc
+++ b/hrc/hrc/misc/markdown.hrc
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hr
 <type name="markdown">
 <annotation><documentation><![CDATA[
 
-markdown.hrc by Roman Kuzmin, aka NightRoman, 2017-11-11
+markdown.hrc by Roman Kuzmin, aka NightRoman, 2017-11-17
 
 * Inline HTML should be valid XML.
 * Opened spans are always colored.
@@ -15,13 +15,6 @@ markdown.hrc by Roman Kuzmin, aka NightRoman, 2017-11-11
 * List levels 4: only items are parsed.
 * List levels 5+: all is colored as code.
 * Indentation: 4/8/12 spaces, 1/2/3 tabs.
-
-Add to proto.hrc:
-
-<prototype name="markdown" group="rare.inet" description="markdown">
-<filename>/\.(text|md|markdown)$/i</filename>
-<location link="...\markdown.hrc"/>
-</prototype>
 
 ]]></documentation></annotation>
 
@@ -83,7 +76,7 @@ Add to proto.hrc:
 <entity name="PEnd" value="^(?:%Top;| {,3}:\s+\S|%Fence;|%i3;%Quote;)?="/>
 
 <scheme name="Escape">
-    <regexp match="/(?{Escape}\\[\\\`\*\_\{\}\[\]\(\)&gt;\#\+\-\.\!:|=&lt;])/"/>
+  <regexp match="/(?{Escape}\\[\\\`\*\_\{\}\[\]\(\)&gt;\#\+\-\.\!:|=&lt;])/"/>
 </scheme>
 
 <scheme name="CodeSpan">
@@ -166,6 +159,11 @@ Add to proto.hrc:
 
 <scheme name="Wrap">
   <regexp match="/(\S )?#2(?{Wrap} +)$/"/>
+</scheme>
+
+<scheme name="Quote">
+  <inherit scheme="Wrap"/>
+  <inherit scheme="def:empty"/>
 </scheme>
 
 <scheme name="Text">
@@ -287,7 +285,7 @@ Add to proto.hrc:
 
   <regexp match="/^(?{Abbreviation}%Abbr;.*)/"/>
 
-  <block scheme="def:empty" region="QuoteText"
+  <block scheme="Quote" region="QuoteText"
   start="/(?{start}%i3;%QuoteMark;)/" end="/(?{end})%LEnd;/"/>
 
   <block scheme="List"

--- a/hrc/hrc/misc/markdown.hrc
+++ b/hrc/hrc/misc/markdown.hrc
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hr
 <type name="markdown">
 <annotation><documentation><![CDATA[
 
-markdown.hrc by Roman Kuzmin, aka NightRoman, 2013-01-07
+markdown.hrc by Roman Kuzmin, aka NightRoman, 2017-11-11
 
 * Inline HTML should be valid XML.
 * Opened spans are always colored.
@@ -66,7 +66,7 @@ Add to proto.hrc:
 <entity name="Abbr" value=" {,3}\*\[[^\]]+\]:"/>
 <entity name="Email" value="[^@&gt;]+@[^.&gt;]+\.[^&gt;]+"/>
 <entity name="Fence" value="\~{3,}\s*$"/>
-<entity name="FenceMark" value="(?{FenceMark}\~{3,})\s*$"/>
+<entity name="FenceMark" value="(?{FenceMark}(?:`{3,}|\~{3,}))"/>
 <entity name="Head" value="#{1,6}"/>
 <entity name="ID" value="[a-zA-Z][a-zA-Z0-9_\-:.]*"/>
 <entity name="List1" value="(?:[*+\-]|\d+\.)\s+\S"/>
@@ -83,218 +83,218 @@ Add to proto.hrc:
 <entity name="PEnd" value="^(?:%Top;| {,3}:\s+\S|%Fence;|%i3;%Quote;)?="/>
 
 <scheme name="Escape">
-	<regexp match="/(?{Escape}\\[\\\`\*\_\{\}\[\]\(\)&gt;\#\+\-\.\!:|=&lt;])/"/>
+    <regexp match="/(?{Escape}\\[\\\`\*\_\{\}\[\]\(\)&gt;\#\+\-\.\!:|=&lt;])/"/>
 </scheme>
 
 <scheme name="CodeSpan">
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}`+)/" end="/(?{end}\y{start})|%LEnd;/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}`+)/" end="/(?{end}\y{start})|%LEnd;/"/>
 </scheme>
 
 <scheme name="PCodeSpan">
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}`+)/" end="/(?{end}\y{start})|%PEnd;/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}`+)/" end="/(?{end}\y{start})|%PEnd;/"/>
 </scheme>
 
 <scheme name="Link">
-	<inherit scheme="Escape"/>
+  <inherit scheme="Escape"/>
 
-	<block scheme="Escape" region="LinkText"
-	start="/\[/" end="/\]/"/>
+  <block scheme="Escape" region="LinkText"
+  start="/\[/" end="/\]/"/>
 </scheme>
 
 <scheme name="LinkSpan">
-	<block scheme="Link" region="LinkText" priority="low"
-	start="/(?{start}(?{LinkMark}!?\[))/" end="/(?{end}(?{LinkMark}\](?:\([^)]*\)| ?\[[^\]]*\])?))|%LEnd;/"/>
+  <block scheme="Link" region="LinkText" priority="low"
+  start="/(?{start}(?{LinkMark}!?\[))/" end="/(?{end}(?{LinkMark}\](?:\([^)]*\)| ?\[[^\]]*\])?))|%LEnd;/"/>
 </scheme>
 
 <scheme name="PLinkSpan">
-	<block scheme="Link" region="LinkText" priority="low"
-	start="/(?{start}(?{LinkMark}!?\[))/" end="/(?{end}(?{LinkMark}\](?:\([^)]*\)| ?\[[^\]]*\])?))|%PEnd;/"/>
+  <block scheme="Link" region="LinkText" priority="low"
+  start="/(?{start}(?{LinkMark}!?\[))/" end="/(?{end}(?{LinkMark}\](?:\([^)]*\)| ?\[[^\]]*\])?))|%PEnd;/"/>
 </scheme>
 
 <scheme name="Base">
-	<inherit scheme="Escape"/>
-	<inherit scheme="CodeSpan"/>
-	<inherit scheme="LinkSpan"/>
+  <inherit scheme="Escape"/>
+  <inherit scheme="CodeSpan"/>
+  <inherit scheme="LinkSpan"/>
 
-	<regexp match="/(?{LinkMark}&lt;)(?{LinkText}%URI;|%Email;)(?{LinkMark}&gt;)/"/>
+  <regexp match="/(?{LinkMark}&lt;)(?{LinkText}%URI;|%Email;)(?{LinkMark}&gt;)/"/>
 
-	<block scheme="xml:xml"
-	start="/\M&lt;(?:!--|\d?!\w+(?:\s|\/?&gt;|$))/" end="//"/>
+  <block scheme="xml:xml"
+  start="/\M&lt;(?:!--|\d?!\w+(?:\s|\/?&gt;|$))/" end="//"/>
 </scheme>
 
 <scheme name="EmSpan">
-	<block scheme="StrongSpan" region="EmText" priority="low"
-	start="/(?{start}\*)[^\s*]?=/" end="/[^\s*]?#1(?{end}\*)|%LEnd;/"/>
+  <block scheme="StrongSpan" region="EmText" priority="low"
+  start="/(?{start}\*)[^\s*]?=/" end="/[^\s*]?#1(?{end}\*)|%LEnd;/"/>
 
-	<block scheme="StrongSpan" region="EmText"
-	start="/(?:^|\s?#1)(?{start}_)[^\s_]?=/" end="/[^\s_]?#1(?{end}_)(?:$|\s?=)|%LEnd;/"/>
+  <block scheme="StrongSpan" region="EmText"
+  start="/(?:^|\s?#1)(?{start}_)[^\s_]?=/" end="/[^\s_]?#1(?{end}_)(?:$|\s?=)|%LEnd;/"/>
 
-	<inherit scheme="Base"/>
+  <inherit scheme="Base"/>
 </scheme>
 
 <scheme name="PEmSpan">
-	<block scheme="PStrongSpan" region="EmText" priority="low"
-	start="/(?{start}\*)[^\s*]?=/" end="/[^\s*]?#1(?{end}\*)|%PEnd;/"/>
+  <block scheme="PStrongSpan" region="EmText" priority="low"
+  start="/(?{start}\*)[^\s*]?=/" end="/[^\s*]?#1(?{end}\*)|%PEnd;/"/>
 
-	<block scheme="PStrongSpan" region="EmText"
-	start="/(?:^|\s?#1)(?{start}_)[^\s_]?=/" end="/[^\s_]?#1(?{end}_)(?:$|\s?=)|%PEnd;/"/>
+  <block scheme="PStrongSpan" region="EmText"
+  start="/(?:^|\s?#1)(?{start}_)[^\s_]?=/" end="/[^\s_]?#1(?{end}_)(?:$|\s?=)|%PEnd;/"/>
 
-	<inherit scheme="Base"/>
+  <inherit scheme="Base"/>
 </scheme>
 
 <scheme name="StrongSpan">
-	<block scheme="EmSpan" region="StrongText"
-	start="/(?{start}\*{2,3})[^\s*]?=/" end="/[^\s*]?#1(?{end}\y{start})|%LEnd;/"/>
+  <block scheme="EmSpan" region="StrongText"
+  start="/(?{start}\*{2,3})[^\s*]?=/" end="/[^\s*]?#1(?{end}\y{start})|%LEnd;/"/>
 
-	<block scheme="EmSpan" region="StrongText"
-	start="/(?:^|\s?#1)(?{start}_{2,3})[^\s_]?=/" end="/[^\s_]?#1(?{end}\y{start})(?:$|\s?=)|%LEnd;/"/>
+  <block scheme="EmSpan" region="StrongText"
+  start="/(?:^|\s?#1)(?{start}_{2,3})[^\s_]?=/" end="/[^\s_]?#1(?{end}\y{start})(?:$|\s?=)|%LEnd;/"/>
 
-	<inherit scheme="Base"/>
+  <inherit scheme="Base"/>
 </scheme>
 
 <scheme name="PStrongSpan">
-	<block scheme="PEmSpan" region="StrongText"
-	start="/(?{start}\*{2,3})[^\s*]?=/" end="/[^\s*]?#1(?{end}\y{start})|%PEnd;/"/>
+  <block scheme="PEmSpan" region="StrongText"
+  start="/(?{start}\*{2,3})[^\s*]?=/" end="/[^\s*]?#1(?{end}\y{start})|%PEnd;/"/>
 
-	<block scheme="PEmSpan" region="StrongText"
-	start="/(?:^|\s?#1)(?{start}_{2,3})[^\s_]?=/" end="/[^\s_]?#1(?{end}\y{start})(?:$|\s?=)|%PEnd;/"/>
+  <block scheme="PEmSpan" region="StrongText"
+  start="/(?:^|\s?#1)(?{start}_{2,3})[^\s_]?=/" end="/[^\s_]?#1(?{end}\y{start})(?:$|\s?=)|%PEnd;/"/>
 
-	<inherit scheme="Base"/>
+  <inherit scheme="Base"/>
 </scheme>
 
 <scheme name="Wrap">
-	<regexp match="/(\S )?#2(?{Wrap} +)$/"/>
+  <regexp match="/(\S )?#2(?{Wrap} +)$/"/>
 </scheme>
 
 <scheme name="Text">
-	<inherit scheme="Wrap"/>
-	<inherit scheme="Base"/>
-	<inherit scheme="EmSpan"/>
-	<inherit scheme="StrongSpan"/>
+  <inherit scheme="Wrap"/>
+  <inherit scheme="Base"/>
+  <inherit scheme="EmSpan"/>
+  <inherit scheme="StrongSpan"/>
 </scheme>
 
 <scheme name="Para">
-	<inherit scheme="Text">
-		<virtual scheme="CodeSpan" subst-scheme="PCodeSpan"/>
-		<virtual scheme="LinkSpan" subst-scheme="PLinkSpan"/>
-		<virtual scheme="EmSpan" subst-scheme="PEmSpan"/>
-		<virtual scheme="StrongSpan" subst-scheme="PStrongSpan"/>
-	</inherit>
+  <inherit scheme="Text">
+    <virtual scheme="CodeSpan" subst-scheme="PCodeSpan"/>
+    <virtual scheme="LinkSpan" subst-scheme="PLinkSpan"/>
+    <virtual scheme="EmSpan" subst-scheme="PEmSpan"/>
+    <virtual scheme="StrongSpan" subst-scheme="PStrongSpan"/>
+  </inherit>
 </scheme>
 
 <scheme name="Head">
-	<regexp match="/(?{HeadMark}#*\s*)?(?{Anchor}\{#%ID;\})(?{HeadMark}\s*#*\s*)$/"/>
-	<regexp match="/(?{HeadMark}#+\s*)$/"/>
+  <regexp match="/(?{HeadMark}#*\s*)?(?{Anchor}\{#%ID;\})(?{HeadMark}\s*#*\s*)$/"/>
+  <regexp match="/(?{HeadMark}#+\s*)$/"/>
 
-	<inherit scheme="Base"/>
-	<inherit scheme="EmSpan"/>
-	<inherit scheme="StrongSpan"/>
+  <inherit scheme="Base"/>
+  <inherit scheme="EmSpan"/>
+  <inherit scheme="StrongSpan"/>
 </scheme>
 
 <scheme name="Item3">
-	<block scheme="def:empty" region="QuoteText"
-	start="/(?{start}%s12;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;{,3}%Fence;|%i11;%Quote;)/"/>
+  <block scheme="def:empty" region="QuoteText"
+  start="/(?{start}%s12;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;{,3}%Fence;|%i11;%Quote;)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}%x12;%FenceMark;)/" end="/(?{end}%x12;(?{FenceMark}\y{FenceMark})\s*$)/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}%x12;%FenceMark;)/" end="/(?{end}%x12;(?{FenceMark}\y{FenceMark})\s*$)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}^ {16,}|\t{4,})/" end="/(?{end})\M%i15;\S/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}^ {16,}|\t{4,})/" end="/(?{end})\M%i15;\S/"/>
 
-	<block scheme="Text" region="ListText"
-	start="/(?{start}%s12;%ListMark;)/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,3}%Fence;|%i19;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/(?{start}%s12;%ListMark;)/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,3}%Fence;|%i19;%Quote;)/"/>
 
-	<block scheme="Text" region="ListText"
-	start="/\M(?{start}%s12;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,3}%Fence;|%i15;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/\M(?{start}%s12;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,3}%Fence;|%i15;%Quote;)/"/>
 </scheme>
 
 <scheme name="List3">
-	<block scheme="Text" region="ListText"
-	start="/~/" end="/\M(?:%Top;|%i15;%List2;|%x4;{,3}%Fence;|%i15;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/~/" end="/\M(?:%Top;|%i15;%List2;|%x4;{,3}%Fence;|%i15;%Quote;)/"/>
 
-	<block scheme="Item3"
-	start="//" end="/\M%i11;\S/"/>
+  <block scheme="Item3"
+  start="//" end="/\M%i11;\S/"/>
 </scheme>
 
 <scheme name="Item2">
-	<block scheme="def:empty" region="QuoteText"
-	start="/(?{start}%s8;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;{,2}%Fence;|%i7;%Quote;)/"/>
+  <block scheme="def:empty" region="QuoteText"
+  start="/(?{start}%s8;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;{,2}%Fence;|%i7;%Quote;)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}%x8;%FenceMark;)/" end="/(?{end}%x8;(?{FenceMark}\y{FenceMark})\s*$)/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}%x8;%FenceMark;)/" end="/(?{end}%x8;(?{FenceMark}\y{FenceMark})\s*$)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}^ {12,}|\t{3,})/" end="/(?{end})\M%i11;\S/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}^ {12,}|\t{3,})/" end="/(?{end})\M%i11;\S/"/>
 
-	<block scheme="List3"
-	start="/(?{start}%s8;%ListMark;)/" end="/(?{end})/"/>
+  <block scheme="List3"
+  start="/(?{start}%s8;%ListMark;)/" end="/(?{end})/"/>
 
-	<block scheme="Text" region="ListText"
-	start="/\M(?{start}%s8;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,2}%Fence;|%i11;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/\M(?{start}%s8;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,2}%Fence;|%i11;%Quote;)/"/>
 </scheme>
 
 <scheme name="List2">
-	<block scheme="Text" region="ListText"
-	start="/~/" end="/\M(?:%Top;|%i11;%List2;|%x4;{,2}%Fence;|%i11;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/~/" end="/\M(?:%Top;|%i11;%List2;|%x4;{,2}%Fence;|%i11;%Quote;)/"/>
 
-	<block scheme="Item2"
-	start="//" end="/\M%i7;\S/"/>
+  <block scheme="Item2"
+  start="//" end="/\M%i7;\S/"/>
 </scheme>
 
 <scheme name="Item">
-	<block scheme="def:empty" region="QuoteText"
-	start="/(?{start}%s4;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;%Fence;|%i3;%Quote;)/"/>
+  <block scheme="def:empty" region="QuoteText"
+  start="/(?{start}%s4;%QuoteMark;)/" end="/(?{end})\M(?:%Top;|^\s+%List1;|%x4;%Fence;|%i3;%Quote;)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}%x4;%FenceMark;)/" end="/(?{end}%x4;(?{FenceMark}\y{FenceMark})\s*$)/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}%x4;%FenceMark;)/" end="/(?{end}%x4;(?{FenceMark}\y{FenceMark})\s*$)/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}^ {8,}|\t{2,})/" end="/(?{end})\M%i7;\S/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}^ {8,}|\t{2,})/" end="/(?{end})\M%i7;\S/"/>
 
-	<block scheme="List2"
-	start="/(?{start}%s4;%ListMark;)/" end="/(?{end})/"/>
+  <block scheme="List2"
+  start="/(?{start}%s4;%ListMark;)/" end="/(?{end})/"/>
 
-	<block scheme="Text" region="ListText"
-	start="/\M(?{start}%s4;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,1}%Fence;|%s4;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/\M(?{start}%s4;)\S/" end="/(?{end})\M(?:%Top;|^\s*%List2;|%x4;{,1}%Fence;|%s4;%Quote;)/"/>
 </scheme>
 
 <scheme name="List">
-	<block scheme="Text" region="ListText"
-	start="/~/" end="/\M(?:%Top;|%i7;%List2;|%x4;{,1}%Fence;|%i7;%Quote;)/"/>
+  <block scheme="Text" region="ListText"
+  start="/~/" end="/\M(?:%Top;|%i7;%List2;|%x4;{,1}%Fence;|%i7;%Quote;)/"/>
 
-	<block scheme="Item"
-	start="//" end="/\M%i3;\S/"/>
+  <block scheme="Item"
+  start="//" end="/\M%i3;\S/"/>
 </scheme>
 
 <scheme name="markdown">
-	<regexp match="/^(?{Rule}%Rule;)/"/>
+  <regexp match="/^(?{Rule}%Rule;)/"/>
 
-	<block scheme="Head" region="HeadText"
-	start="/^(?{HeadMark}#{4,6})/" end="/$/"/>
+  <block scheme="Head" region="HeadText"
+  start="/^(?{HeadMark}#{4,6})/" end="/$/"/>
 
-	<block scheme="Head" region="HeadText"
-	start="/^(?{HeadMark}#{1,3})(?{def:Outlined}.*)?=/" end="/$/"/>
+  <block scheme="Head" region="HeadText"
+  start="/^(?{HeadMark}#{1,3})(?{def:Outlined}.*)?=/" end="/$/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}^ {4,}|\t+)\S.*/" end="/(?{end})\M%i3;\S/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}^ {4,}|\t+)\S.*/" end="/(?{end})\M%i3;\S/"/>
 
-	<block scheme="def:empty" region="Code"
-	start="/(?{start}^%FenceMark;)\s*$/" end="/(?{end}^(?{FenceMark}\y{FenceMark}))\s*$/"/>
+  <block scheme="def:empty" region="Code"
+  start="/(?{start}^%FenceMark;).*$/" end="/(?{end}^(?{FenceMark}\y{FenceMark})).*$/"/>
 
-	<regexp match="/^(?{Reference}%Ref;.*)/"/>
+  <regexp match="/^(?{Reference}%Ref;.*)/"/>
 
-	<regexp match="/^(?{Abbreviation}%Abbr;.*)/"/>
+  <regexp match="/^(?{Abbreviation}%Abbr;.*)/"/>
 
-	<block scheme="def:empty" region="QuoteText"
-	start="/(?{start}%i3;%QuoteMark;)/" end="/(?{end})%LEnd;/"/>
+  <block scheme="def:empty" region="QuoteText"
+  start="/(?{start}%i3;%QuoteMark;)/" end="/(?{end})%LEnd;/"/>
 
-	<block scheme="List"
-	start="/(?{start}%i3;%ListMark;)/" end="/(?{end})/"/>
+  <block scheme="List"
+  start="/(?{start}%i3;%ListMark;)/" end="/(?{end})/"/>
 
-	<block scheme="Para"
-	start="/\M(?{start}%i3;)\S/" end="/(?{end})%PEnd;/"/>
+  <block scheme="Para"
+  start="/\M(?{start}%i3;)\S/" end="/(?{end})%PEnd;/"/>
 </scheme>
 </type>
 </hrc>


### PR DESCRIPTION
- support fenced code blocks with language names
- replace indentation tabs with spaces
- support end double spaces in quotes