### PR TITLE
nix.hrc: add missing blockstring escaping

### DIFF
--- a/hrc/hrc/base/nix.hrc
+++ b/hrc/hrc/base/nix.hrc
@@ -50,6 +50,8 @@
       <inherit scheme="SpacesAsErrors"/>
 
       <regexp match="/&apos;&apos;\$/"                                          region0="StringEscape"/>
+      <regexp match="/&apos;&apos;\\./"                                         region0="StringEscape"/>
+      <regexp match="/&apos;&apos;\\$/"                                         region0="StringEscape"/>
       <regexp match="/&apos;&apos;&apos;/"                                      region0="StringEscape"/>
       <block start="/(\$\{)/" end="/(\})/" scheme="NixExpression" region="Code" region00="Interpolation" region01="PairStart" region10="Interpolation" region11="PairEnd"/>
     </scheme>


### PR DESCRIPTION
This form of escape sequence was missing

https://github.com/NixOS/nix/blob/6a5bf9b1438ed0b721657568fbb3a7c0b829e89e/src/libexpr/lexer.l#L186-L187