### PR TITLE
cpp.hrc: allow curly brackets inside expressions, fixes #78

### DIFF
--- a/hrc/hrc/base/cpp.hrc
+++ b/hrc/hrc/base/cpp.hrc
@@ -79,6 +79,9 @@
    region11="c:StructureSymbol"
   />
   
+  <!-- Hack for lambdas and list initialization -->
+  <block start="/(\{)/" end="/(\})/" scheme="Expression"
+        region00="def:SymbolStrong" region01="def:PairStart" region10="def:SymbolStrong" region11="def:PairEnd"/>
 
   <!-- !!EE: Block #2 template support -->
   <!-- Colorer 4:


### PR DESCRIPTION
C++11 allowed curly brackets in expressions inside round brackets where
they were not allowed before:
* Lambda functions: ([](){ return 1; })();
* List initialization: vector({1, 2, 3})

This patch adds {} as correct pair inside 'Expression' region,
hence they are not highlighted as errors anymore.

Fixes #78 