### PR TITLE
highlight the most frequestly used unix commands simplify "grep" highlighting

### DIFF
--- a/hrc/hrc/scripts/sh-keywords.ent.hrc
+++ b/hrc/hrc/scripts/sh-keywords.ent.hrc
@@ -123,6 +123,8 @@
        <word name="find"/>
        <word name="xargs"/>
        <word name="wc"/>
+       <word name="sort"/>
+       <word name="uniq"/>
 
        <word name="alias"/>
        <word name="bg"/>

--- a/hrc/hrc/scripts/sh-keywords.ent.hrc
+++ b/hrc/hrc/scripts/sh-keywords.ent.hrc
@@ -115,9 +115,15 @@
      </keywords>
 <!-- test conditions -->
 
-<!-- builtin commands -->
+<!-- builtin and some external frequently used commands -->
     <keywords region="command.sys">
        <word name="sed"/>
+       <word name="awk"/>
+       <word name="grep"/>
+       <word name="find"/>
+       <word name="xargs"/>
+       <word name="wc"/>
+
        <word name="alias"/>
        <word name="bg"/>
        <word name="bind"/>
@@ -161,7 +167,6 @@
        <word name="test"/>
        <word name="times"/>
        <word name="trap"/>
-       <word name="type"/>
        <word name="type"/>
        <word name="ulimit"/>
        <word name="umask"/>

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -185,12 +185,12 @@
   scheme="str.cont" region="string"
   region00="def:PairStart" region10="def:PairEnd"
   />
- <block start="/(grep) (\-\w+)?\s*(&apos;)/" end="/(&apos;)/"
+ <!--block start="/(\bgrep) (\-\w+)?\s*(&apos;)/" end="/(&apos;)/"
   scheme="regexp:pcre.regexp" region="string"
   region00="def:PairStart" region10="def:PairEnd"
   region01="command.sys" region02="op"
   region03="def:StringEdge" region11="def:StringEdge"
- />
+ /-->
  <!--block start="/(echo) (\-\w+)?\s*\M[^&quot;&apos;`;\)\}]+/"
   end="/$/" priority="low" content-priority="low"
   scheme="var" region="string"

--- a/hrc/hrc/scripts/sh.hrc
+++ b/hrc/hrc/scripts/sh.hrc
@@ -185,7 +185,7 @@
   scheme="str.cont" region="string"
   region00="def:PairStart" region10="def:PairEnd"
   />
- <!--block start="/(\bgrep) (\-\w+)?\s*(&apos;)/" end="/(&apos;)/"
+ <!--block start="/(\b[efz]?grep) (\-\w+)?\s*(&apos;)/" end="/(&apos;)/"
   scheme="regexp:pcre.regexp" region="string"
   region00="def:PairStart" region10="def:PairEnd"
   region01="command.sys" region02="op"


### PR DESCRIPTION
Highlight the most frequently used commands:
- sed (it is already declared)
- awk
- grep
- find
- xargs
- wc
- sort
- uniq

Simplify "grep" highlighting:
- no special coloring for something similar to "grep -q".
