### PR TITLE
Associate .ts files (TypeScript) with JavaScript in proto.hrc.

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -362,7 +362,7 @@
   </prototype>
   <prototype name="jScript" group="inet" description="JavaScript">
     <location link="inet/jscript.hrc"/>
-    <filename>/\.(js|mocha)$/i</filename>
+    <filename>/\.(js|mocha|ts)$/i</filename>
   </prototype>
   <prototype name="actionscript" group="inet" description="ActionScript">
     <location link="inet/actionscript.hrc"/>


### PR DESCRIPTION
As far as I can see `.ts` is not used, so there should be no conflicts introduced.

TypeScript is a super set of JavaScript, so that this association works quite well.
In any case it is much better than C++ currently selected due to similar header comments.