### PR TITLE
support CFR, another java decompiler

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -99,6 +99,7 @@
     <location link="base/java.hrc"/>
     <filename>/\.ja(va|v|d)$/i</filename>
     <firstline weight='2'>/^\/\/ Decompiled by Jad/</firstline>
+    <firstline weight='2'>/^\/\*\r?\n \* Decompiled with CFR/</firstline><!-- support another java decompiler https://github.com/leibnitz27/cfr -->
     <parameters>
       <param name="tabs-as-errors" value="false" description="Shows tabulation symbol as error"/>
       <param name="spaces-as-errors" value="false" description="Shows trailing spaces as error"/>


### PR DESCRIPTION
Jad is old-fashioned and sometimes not able to correctly decompile class files. 

CFR is another java decompiler supporting modern Java features. It lives at https://github.com/leibnitz27/cfr. It decompiles class files prepending the following minimal header (version is optional):
```
/*
 * Decompiled with CFR 0.150.
 */
```
It could be reasonable to support CFR output.