### PR TITLE
Update proto.hrc

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -363,7 +363,7 @@
   </prototype>
   <prototype name="jScript" group="inet" description="JavaScript">
     <location link="inet/jscript.hrc"/>
-    <filename>/\.(js|mocha|ts)$/i</filename>
+    <filename>/\.(cjs|mjs|js|mocha|ts)$/i</filename>
   </prototype>
   <prototype name="actionscript" group="inet" description="ActionScript">
     <location link="inet/actionscript.hrc"/>


### PR DESCRIPTION
When working with Node.js Javascript; .mjs is used for modules, and .cjs is used for 'commonjs'.