### PR TITLE
Associate .editorconfig files with "config" in proto.hrc.

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -582,7 +582,7 @@
   </prototype>
   <prototype name="config" group="scripts" description="Config, INI and CTL">
     <location link="scripts/config.hrc"/>
-    <filename>/\.(ctl|tpl|ini|cfg|inf|srg|conf|types|tab|dof|dsk|lng)$/i</filename>
+    <filename>/\.(ctl|tpl|ini|cfg|inf|srg|conf|types|tab|dof|dsk|lng|editorconfig)$/i</filename>
     <firstline>/^[;\[\#]/</firstline>
   </prototype>
   <prototype name="awk" group="scripts" description="AWK">


### PR DESCRIPTION
https://editorconfig.org
These files are used by many modern text editors and their plugins.