### PR TITLE
Update csharp.hrc and amend graphql.hrc prototype.

### DIFF
--- a/hrc/hrc/base/csharp.hrc
+++ b/hrc/hrc/base/csharp.hrc
@@ -36,7 +36,7 @@ With help of:
       </scheme>
 
      <scheme name="vbstring.content">
-     	<regexp match="/(?{string.escape}&quot;&quot;)/"/>
+        <regexp match="/(?{string.escape}&quot;&quot;)/"/>
      </scheme>
 
       <scheme name="csharp">
@@ -58,13 +58,17 @@ With help of:
 
          <regexp><![CDATA[
            /^ \M \s*
-           (\w [\w*\[\]\s]+? [*\[\]\s]) (delegate \s* \([\w_*~,\[\]\s]*\)\s*)?
+           (\w [\w*\[\]\s.<,>]*? [*\[\]\s]) (delegate \s* \([\w_*~,\[\]\s]*\)\s*)?
 
            (?{csharp:FuncOutline}
-            ([\w.]+?)
+            \w+?
            )
 
-           (\sfor)?~4 (\sif)?~3 (\swhile)?~6 (\sdo)?~3 (\sswitch)?~7 (\scatch)?~6 (\sforeach)?~8
+           \s*
+
+           (for)?~3 (if)?~2 (while)?~5 (do)?~2 (switch)?~6 (catch)?~5 (foreach)?~7
+
+           (< \s* \w [\w,\s]*? >)?
 
            \s* \( (.* \( [^\(\)]* \))* ( [^\)]*?\) | [^\);]*? )
            \s* ($|\{|\/) /x
@@ -118,6 +122,8 @@ With help of:
          <keywords region="csKeyword">
             <word name="abstract"/>
             <word name="as"/>
+            <word name="async"/>
+            <word name="await"/>
             <word name="base"/>
             <word name="bool"/>
             <word name="yield break"/>

--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -398,6 +398,10 @@
     <location link="inet/mxml.hrc"/>
     <filename>/\.mxml$/i</filename>
   </prototype>
+  <prototype name="graphql" group="inet" description="GraphQL">
+    <filename>/\.(graphql|gql)$/i</filename>
+    <location link="inet/graphql.hrc"/>
+  </prototype>
 
 
   <!--  xml types  -->
@@ -601,10 +605,6 @@
   <prototype name="markdown" group="scripts" description="markdown">
     <filename>/\.(text|md|markdown)$/i</filename>
     <location link="misc/markdown.hrc"/>
-  </prototype>
-  <prototype name="graphql" group="inet" description="GraphQL">
-    <filename>/\.(graphql|gql)$/i</filename>
-    <location link="inet/graphql.hrc"/>
   </prototype>
 
 


### PR DESCRIPTION

## GraphQL prototype

Moved recently added `graphql.hrc` to other `inet` group declarations in the prototype file.
Otherwise GraphQL is shown in its own separate `inet` group with just one item in it.

## New C# keywords

Added new keywords `async` and `await`, frequently used nowadays.

Technically they are context dependent, i.e. in some cases they may be used as names.
To define their proper context parsing is tricky, C# schema is rather minimalistic.
For the sake of keeping its simplicity, I suggest just using keywords.

## C# function tweaks

These changes do not affect result colors.
They fix the outline list which was not quite right for many years.

**Return value type**

Replaced

    (\w [\w*\[\]\s]+? [*\[\]\s])

with

    (\w [\w*\[\]\s.<,>]*? [*\[\]\s])

- added `.` because full type names with namespaces contain it
- added `<,>` because generic type names contain these characters
- replaced `+?` with `*?` to support 1 character names, weird but valid

**Function name**

Replaced

    ([\w.]+?)

with

    \w+?

i.e. removed `.` because it is not a valid function name character.
Also removed the redundant regular expression group, the outer outline group is enough.

**Simplified exclusions**

Replaced

    (\sfor)?~4 (\sif)?~3 (\swhile)?~6 (\sdo)?~3 (\sswitch)?~7 (\scatch)?~6 (\sforeach)?~8

with

    \s*

    (for)?~3 (if)?~2 (while)?~5 (do)?~2 (switch)?~6 (catch)?~5 (foreach)?~7

This is simpler and also more correct, it takes into account cases with 2+ spaces before `for`, `if`, etc.

**Generic parameters**

Added

    (< \s* \w [\w,\s]*? >)?

after the function name to support generic type parameters.
