### PR TITLE
Update csharp.hrc and amend graphql.hrc prototype.

### DIFF
--- a/hrc/hrc/base/csharp.hrc
+++ b/hrc/hrc/base/csharp.hrc
@@ -36,7 +36,7 @@ With help of:
       </scheme>
 
      <scheme name="vbstring.content">
-     	<regexp match="/(?{string.escape}&quot;&quot;)/"/>
+        <regexp match="/(?{string.escape}&quot;&quot;)/"/>
      </scheme>
 
       <scheme name="csharp">
@@ -58,13 +58,13 @@ With help of:
 
          <regexp><![CDATA[
            /^ \M \s*
-           (\w [\w*\[\]\s]+? [*\[\]\s]) (delegate \s* \([\w_*~,\[\]\s]*\)\s*)?
+           (\w [\w*\[\]\s.<,>]*? [*\[\]\s]) (delegate \s* \([\w_*~,\[\]\s]*\)\s*)?
 
            (?{csharp:FuncOutline}
-            ([\w.]+?)
+            \w+?
            )
 
-           (\sfor)?~4 (\sif)?~3 (\swhile)?~6 (\sdo)?~3 (\sswitch)?~7 (\scatch)?~6 (\sforeach)?~8
+           (\s* < \s* \w [\w,\s]*? >)?
 
            \s* \( (.* \( [^\(\)]* \))* ( [^\)]*?\) | [^\);]*? )
            \s* ($|\{|\/) /x
@@ -118,6 +118,8 @@ With help of:
          <keywords region="csKeyword">
             <word name="abstract"/>
             <word name="as"/>
+            <word name="async"/>
+            <word name="await"/>
             <word name="base"/>
             <word name="bool"/>
             <word name="yield break"/>

--- a/hrc/hrc/base/csharp.hrc
+++ b/hrc/hrc/base/csharp.hrc
@@ -61,7 +61,7 @@ With help of:
            (\w [\w*\[\]\s.<,>]*? [*\[\]\s]) (delegate \s* \([\w_*~,\[\]\s]*\)\s*)?
 
            (?{csharp:FuncOutline}
-            \w+?
+            [\w.]+
            )
 
            (\s* < \s* \w [\w,\s]*? >)?

--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -398,6 +398,10 @@
     <location link="inet/mxml.hrc"/>
     <filename>/\.mxml$/i</filename>
   </prototype>
+  <prototype name="graphql" group="inet" description="GraphQL">
+    <filename>/\.(graphql|gql)$/i</filename>
+    <location link="inet/graphql.hrc"/>
+  </prototype>
 
 
   <!--  xml types  -->
@@ -601,10 +605,6 @@
   <prototype name="markdown" group="scripts" description="markdown">
     <filename>/\.(text|md|markdown)$/i</filename>
     <location link="misc/markdown.hrc"/>
-  </prototype>
-  <prototype name="graphql" group="inet" description="GraphQL">
-    <filename>/\.(graphql|gql)$/i</filename>
-    <location link="inet/graphql.hrc"/>
   </prototype>
 
 


### PR DESCRIPTION
## GraphQL prototype

Moved recently added `graphql.hrc` to other `inet` group declarations in the prototype file.
Otherwise GraphQL is shown in its own separate `inet` group with just one item in it.

## New C# keywords

Added new keywords `async` and `await`, frequently used nowadays.

Technically they are context dependent, i.e. in some cases they may be used as names.
To define their proper context parsing is tricky, C# schema is rather minimalistic.
For the sake of keeping its simplicity, I suggest just using keywords.
(I'll improve this later if there are drawbacks/complains).

## C# function tweaks

These changes do not affect result colors.
They fix the outline list which was not quite right for many years.

**Return value type**

Replaced

    (\w [\w*\[\]\s]+? [*\[\]\s])

with

    (\w [\w*\[\]\s.<,>]*? [*\[\]\s])

- added `.` because full type names with namespaces contain it
- added `<,>` because generic type names contain these characters
- replaced `+?` with `*?` to support 1 character names, weird but valid

**Removed exclusions**

Removed

    (\sfor)?~4 (\sif)?~3 (\swhile)?~6 (\sdo)?~3 (\sswitch)?~7 (\scatch)?~6 (\sforeach)?~8

I cannot find cases when this code makes any useful difference on some very large C# code base.
This code looks redundant or it's value is insignificant, I suggest removing it.

**Generic parameters**

Added

    (\s* < \s* \w [\w,\s]*? >)?

after the function name to support generic type parameters.
