### PR TITLE
regex.hrc/pcre.base: support named capture groups and backreferences

### DIFF
--- a/hrc/hrc/lib/regexp.hrc
+++ b/hrc/hrc/lib/regexp.hrc
@@ -144,6 +144,7 @@
  <regexp match="/\\[aenrtfv]/" region0="Symbol"/> <!-- спецсимволы  -->
  <regexp match="/\\c./" region0="Symbol"/>       <!-- спецсимволы  -->
  <regexp match="/\\[0-9a-fA-F]{2}/" region0="SpecOperator"/>	   <!-- Классы символов -->
+ <regexp match="/\\k(&lt;\d?!\w+&gt;|'\d?!\w+')/" region0="SpecOperator"/> <!-- named backreference -->
  <inherit scheme="std.base"/>
 </scheme>
 
@@ -178,6 +179,11 @@
  <inherit scheme="string"/>
  <block start="/(\()(\?&lt;?[\=\!])/" end="/(\))/" scheme="pcre.regexp"
   region00="def:PairStart" region01="Quote" region02="Operator"
+  region10="def:PairEnd" region11="Quote"
+ />
+ <!-- named capture groups -->
+ <block start="/(\()(\?(&lt;\d?!\w+&gt;|'\d?!\w+'))/" end="/(\))/" scheme="pcre.regexp"
+  region00="def:PairStart" region01="Quote" region02="SpecOperator"
   region10="def:PairEnd" region11="Quote"
  />
  <block start="/(\s\s+|\x09)\#/" end="/$/"


### PR DESCRIPTION
PCRE specs:

- [NAMED CAPTURE GROUPS](https://www.pcre.org/current/doc/html/pcre2pattern.html#SEC16)
- [BACKREFERENCES](https://www.pcre.org/current/doc/html/pcre2pattern.html#backreferences)

According to the specs, at least these two forms are supported:

```
(?<name>bar) \k<name>
(?'name'bar) \k'name'
```

Currently, the scheme does not recognise named capture groups and treats named backreferences as syntax errors.

<https://regex101.com/> shows that both forms are valid in PCRE2 (PHP >= 7.3.) and PCRE (PHP <7.3).

The commit adds these two forms support to the schema `pcre.base`.

The region `SpecOperator` is chosen to match regions of backreferences (`\1`, etc.).

Colorer results before and after the change (with `visual.hrd` and `powershell` scheme with inherited `regex` scheme):

form 1 `<name>`
![image](https://user-images.githubusercontent.com/927533/149623773-7d19608e-0b6a-4e6a-96a5-72033fd9b137.png)


form 2 `'name'`
![image](https://user-images.githubusercontent.com/927533/149623780-2cc2f752-afa0-4521-ab8d-8d682bb0f322.png)

