### PR TITLE
Added firstline regex for HTML, CSS, SQL and JSON

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -246,18 +246,27 @@
         <location link="inet/html.hrc" />
         <filename>/\.[^ptr]??html?$/i</filename>
         <firstline>/^\s*&lt;((!DOCTYPE\s+)?HTML|!\-\-)/i</firstline>
+	<firstline>/^\s*&lt;(html|head|title|body)\b/i</firstline>
+	<firstline>/^\s*&lt;(div|span|a|script|style|table|form)\b/i</firstline>
         <parameters>
             <param name="conditional-comments" value="true" description="IE conditional comments" />
             <param name="html-pairs" value="true" description="Highlighting some known HTML Pair tags. Please, use &lt; /&gt; syntax for singles like p, td, tr etc.." />
+            <!-- firstline -->
+            <param name='firstlines' value='2' description="lines for 'firstline'" />
+            <param name='firstlinebytes' value='2000' description="bytes for 'firstline'" />
         </parameters>
     </prototype>
 
     <prototype name="css" group="inet" description="css">
         <location link="inet/css.hrc" />
         <filename>/\.css$/i</filename>
+	<firstline>/^\s*[\.\#\w-]+\s*\{/i</firstline>	
         <parameters>
             <param name="html-css" value="true" description="Default use css for HTML" />
             <param name="svg-css" value="false" description="Default use css for SVG" />
+            <!-- firstline -->
+            <param name='firstlines' value='2' description="lines for 'firstline'" />
+            <param name='firstlinebytes' value='2000' description="bytes for 'firstline'" />
         </parameters>
     </prototype>
     <prototype name="html-css" group="inet" description="css for html">
@@ -570,8 +579,13 @@
     <prototype name="sql" group="database" description="SQL, PL/SQL">
         <location link="db/sql.hrc" />
         <filename>/\.sql$/i</filename>
+	<firstline>/^\s*(SELECT|INSERT INTO|UPDATE|DELETE FROM)\s+.*?\s+(FROM|INTO|SET|WHERE)\b/i</firstline>
+	<firstline>/^\s*--.*$|^\s*\/\*.*\*\/$/i</firstline>
         <parameters>
             <param name="backslash_escapes" value="true" description="Treat \' in character literals as an escaped '" />
+            <!-- firstline -->
+            <param name='firstlines' value='10' description="lines for 'firstline'" />
+            <param name='firstlinebytes' value='2000' description="bytes for 'firstline'" />
         </parameters>
     </prototype>
     <prototype name="mysql" group="database" description="MySQL">
@@ -1006,6 +1020,7 @@
     <prototype name="json" group="rare" description="JSON">
         <location link="rare/json.hrc" />
         <filename weight='3'>/\.json$/i</filename>
+	<firstline weight="3">/^\s*\{\s*"\w+":/i</firstline>
     </prototype>
     <prototype name="yaml" group="rare" description="YAML">
         <location link="rare/yaml.hrc" />


### PR DESCRIPTION
Added <firstline> regex for JSON, HTML, CSS and SQL. Tested a fair bit, eg with similar languages like generic XML to hopefully avoid collisions. Also set some weights which I think may be right. Currently in-use on tohtml.com

**CSS**: This pattern aims to catch lines starting with optional whitespace, followed by a selector (class ., ID #, or element/tag name), and then an opening brace {.

**JSON**: This pattern matches a JSON object's start, specifically looking for a key defined by double quotes and followed by a colon.

**SQL**: These patterns aim to match common SQL keywords, statements and comments .

**HTML**: These patterns identify HTML through common opening tags, else lines that start with HTML-specific tags.
