### PR TITLE
Fix backticks in for loop in bash scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [shell-posix] Comments are not recognized in case statement
 - [shell-posix] Commands are not recognized correctly after escaped new-line
 - [shell-bash] Redirection symbols < and > inside "magic backticks" block break background highlighting till the end of the file
+- [shell-bash] Fix magic backticks in for loop
 - [smarty] fixed the work of smarty templates
 - [markdown] amend emphasis with underscores
 - [markdown] fix trailing spaces in em and strong

--- a/hrc/hrc/scripts/shell-bash.hrc
+++ b/hrc/hrc/scripts/shell-bash.hrc
@@ -515,6 +515,7 @@
         <virtual scheme="shell-posix:strings" subst-scheme="strings"/>
         <virtual scheme="shell-posix:redirections_start" subst-scheme="redirections_start"/>
         <virtual scheme="shell-posix:script_words" subst-scheme="script_words"/>
+        <virtual scheme="shell-posix:evaluations" subst-scheme="evaluations"/>
     </inherit>
 </scheme>
 


### PR DESCRIPTION
Closes chpock/ck.colorer-schemes#5