### PR TITLE
Add *.xaml to xml prototype.

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -437,7 +437,7 @@
     <!--  xml types  -->
     <prototype name="xml" group="xml" description="xml">
         <location link="xml/xml.hrc" />
-        <filename>/\.(xml|\w*proj|gi2|gpr|ui)$/i</filename>
+        <filename>/\.(xml|\w*proj|gi2|gpr|ui|xaml)$/i</filename>
         <filename>/\.(wxs|fb2)$/i</filename>
         <firstline>/^&lt;\?xml | &lt;\!DOCTYPE | xmlns /x</firstline>
         <firstline>/^\s*&lt;\w+&gt;\s*/</firstline> <!-- (\s+\w+\s*=\*([&quot;&apos;]).+?\2)*\s* -->


### PR DESCRIPTION
`.xaml` is the standard extension for XAML files used in .NET for WPF and UWP applications.
It's XML and should be recognized as XML, so I add this extension to "xml" prototype.

Without this change "smarty" incorrectly takes over due to its rather too broad `firstline` definition

```xml
<prototype name="smarty" group="inet" description="Smarty PHP Templates">
	<location link="inet/smarty.hrc" />
	<filename>/\.smarty$/</filename>
	<filename>/\.tpl$/</filename>
	<firstline>/^\s*[\{&lt;]/x</firstline>
</prototype>
```
