### PR TITLE
Add .mts and .cts file extensions for TypeScript ESM modules

### DIFF
--- a/hrc/hrc/proto.hrc
+++ b/hrc/hrc/proto.hrc
@@ -396,7 +396,7 @@
     </prototype>
     <prototype name="jScript" group="inet" description="JavaScript">
         <location link="inet/jscript.hrc" />
-        <filename>/\.(cjs|mjs|js|mocha|ts)$/i</filename>
+        <filename>/\.(cjs|mjs|js|mocha|ts|mts|cts)$/i</filename>
     </prototype>
     <prototype name="actionscript" group="inet" description="ActionScript">
         <location link="inet/actionscript.hrc" />


### PR DESCRIPTION
Node.js, Bun, Deno etc support .mts and .cts analogous to .mjs and .cjs to force the file to be treated as ESM module. Treat them same as .ts for the purpose of detecting language as TypeScript.